### PR TITLE
Prevent Entity Framework errors during import

### DIFF
--- a/MemeManager/DependencyInjection/DataAccessBootstrapper.cs
+++ b/MemeManager/DependencyInjection/DataAccessBootstrapper.cs
@@ -35,6 +35,7 @@ public class DataAccessBootstrapper
     private static void RegisterNotifiers(IMutableDependencyResolver services, IReadonlyDependencyResolver resolver)
     {
         services.RegisterLazySingleton<IDbChangeNotifier>(() => new DbChangeNotifier());
+        services.RegisterLazySingleton<IImportRequestNotifier>(() => new ImportRequestNotifier());
     }
 
     private static void RegisterServices(IMutableDependencyResolver services, IReadonlyDependencyResolver resolver)

--- a/MemeManager/DependencyInjection/FileAccessBootstrapper.cs
+++ b/MemeManager/DependencyInjection/FileAccessBootstrapper.cs
@@ -18,9 +18,10 @@ public class FileAccessBootstrapper
         var logger = resolver.GetRequiredService<ILogger>();
         // Grab an instance of the change notifier. This is an awful hacky way around doing reactive data properly. I'll figure it out at some point...
         var dbChangeNotifier = resolver.GetRequiredService<IDbChangeNotifier>();
+        var importRequestNotifier = resolver.GetRequiredService<IImportRequestNotifier>();
         var memeService = resolver.GetRequiredService<IMemeService>();
         var categoryService = resolver.GetRequiredService<ICategoryService>();
         var tagService = resolver.GetRequiredService<ITagService>();
-        services.RegisterLazySingleton<IImportService>(() => new ImportService(logger, dbChangeNotifier, memeService, categoryService, tagService));
+        services.RegisterLazySingleton<IImportService>(() => new ImportService(logger, dbChangeNotifier, importRequestNotifier, memeService, categoryService, tagService));
     }
 }

--- a/MemeManager/DependencyInjection/ViewModelsBootstrapper.cs
+++ b/MemeManager/DependencyInjection/ViewModelsBootstrapper.cs
@@ -40,6 +40,7 @@ public static class ViewModelsBootstrapper
     private static void RegisterServices(IMutableDependencyResolver services, IReadonlyDependencyResolver resolver)
     {
         var dbChangeNotifier = resolver.GetRequiredService<IDbChangeNotifier>();
+        var importRequestNotifier = resolver.GetRequiredService<IImportRequestNotifier>();
         var filtersObserver = resolver.GetRequiredService<IFilterObserverService>();
         // Do NOT try to reuse an instance of IDialogService here. Use resolver.GetRequiredService<IDialogService>() every time you need it.
         // Don't ask me why but it makes the UI totally unresponsive if you reuse the same instance. I don't understand it. I will not attempt to understand it.
@@ -61,7 +62,8 @@ public static class ViewModelsBootstrapper
             resolver.GetRequiredService<ICategoriesListViewModel>(),
             resolver.GetRequiredService<IMemesListViewModel>(),
             resolver.GetRequiredService<LayoutConfiguration>(),
-            resolver.GetRequiredService<IImportService>()
+            resolver.GetRequiredService<IImportService>(),
+            importRequestNotifier
         ));
         services.RegisterLazySingleton<IChangeTagsCustomDialogViewModel>(() =>
             new ChangeTagsCustomDialogViewModel(memeService, tagService));

--- a/MemeManager/Models/CategoryTreeNodeModel.cs
+++ b/MemeManager/Models/CategoryTreeNodeModel.cs
@@ -7,7 +7,6 @@ using System.Linq;
 using System.Reactive.Linq;
 using DynamicData.Binding;
 using MemeManager.DependencyInjection;
-using MemeManager.Persistence;
 using MemeManager.Persistence.Entity;
 using MemeManager.Services.Abstractions;
 using Microsoft.Extensions.Logging;
@@ -34,9 +33,6 @@ public class CategoryTreeNodeModel : ReactiveObject
         _name = category.Name;
         _categoryService = categoryService;
         _isExpanded = false;
-        // TODO: This is awful and I hate that I have to do this just to use lazy-loading properties
-        using var context = new MemeManagerContext();
-        context.Categories.Attach(category);
         _hasChildren = category.Children?.Count > 0;
         _memeCount = category.Memes.Count;
 

--- a/MemeManager/Services/Abstractions/ICategoryService.cs
+++ b/MemeManager/Services/Abstractions/ICategoryService.cs
@@ -1,12 +1,10 @@
 ﻿using System.Collections.Generic;
-using MemeManager.Persistence;
 using MemeManager.Persistence.Entity;
 
 namespace MemeManager.Services.Abstractions;
 
 public interface ICategoryService
 {
-    ICategoryService NewInstance(MemeManagerContext separateContext);
     IEnumerable<Category> GetAll();
 
     IEnumerable<Category> GetTopLevelCategories();

--- a/MemeManager/Services/Abstractions/IImportRequestNotifier.cs
+++ b/MemeManager/Services/Abstractions/IImportRequestNotifier.cs
@@ -1,0 +1,48 @@
+﻿using System;
+using System.Collections.Generic;
+using MemeManager.Persistence.Entity;
+
+namespace MemeManager.Services.Abstractions;
+
+public interface IImportRequestNotifier
+{
+    event EventHandler<ImportRequestEventArgs> ImportRequest;
+    event EventHandler<GenerateThumbnailsRequestEventArgs> GenerateThumbnailsRequest;
+    event EventHandler<SetThumbnailsRequestEventArgs> SetThumbnailsRequest;
+
+    void SendImportRequest(string basePath, string[] memePaths);
+    void SendGenerateThumbnailsRequest(IEnumerable<Meme> memes);
+    void SendSetThumbnailsRequest(IEnumerable<(Meme, string?)> memesAndThumbnailPaths);
+}
+
+public class ImportRequestEventArgs : EventArgs
+{
+    public ImportRequestEventArgs(string basePath, string[] memePaths)
+    {
+        BasePath = basePath;
+        MemePaths = memePaths;
+    }
+
+    public string BasePath { get; }
+    public string[] MemePaths { get; }
+}
+
+public class GenerateThumbnailsRequestEventArgs : EventArgs
+{
+    public GenerateThumbnailsRequestEventArgs(IEnumerable<Meme> memes)
+    {
+        Memes = memes;
+    }
+
+    public IEnumerable<Meme> Memes { get; }
+}
+
+public class SetThumbnailsRequestEventArgs : EventArgs
+{
+    public SetThumbnailsRequestEventArgs(IEnumerable<(Meme, string?)> memesAndThumbnailPaths)
+    {
+        MemesAndThumbnailPaths = memesAndThumbnailPaths;
+    }
+
+    public IEnumerable<(Meme, string?)> MemesAndThumbnailPaths { get; }
+}

--- a/MemeManager/Services/Abstractions/IImportService.cs
+++ b/MemeManager/Services/Abstractions/IImportService.cs
@@ -6,6 +6,20 @@ namespace MemeManager.Services.Abstractions;
 
 public interface IImportService
 {
-    public IEnumerable<Meme> ImportFromDirectory(string path);
+    /// <summary>
+    /// Begins the import process for memes at the specified path
+    /// </summary>
+    /// <param name="path">the path to a folder containing memes</param>
+    void ImportFromDirectory(string path);
+
+    /// <summary>
+    /// Called from the main window's ViewModel. PLEASE NEVER CALL THIS METHOD YOURSELF. This is a hacky workaround
+    /// to perform all Entity Framework database operations on the UI thread to keep EF happy.
+    /// </summary>
+    /// <param name="basePath">the folder that was selected during the import screen</param>
+    /// <param name="files">an array of full paths to individual memes to be imported</param>
+    void ImportFromPaths(string basePath, string[] files);
+
     Task GenerateThumbnails(IEnumerable<Meme> importedMemes);
+    void SetThumbnails(IEnumerable<(Meme, string?)> memesAndThumbnailPaths);
 }

--- a/MemeManager/Services/Abstractions/IMemeService.cs
+++ b/MemeManager/Services/Abstractions/IMemeService.cs
@@ -18,6 +18,8 @@ public interface IMemeService
 
     Meme Create(Meme newMeme);
 
+    void BulkCreate(IEnumerable<Meme> memes);
+
     Meme? DeleteById(int id);
 
     Meme SetCategory(Meme meme, Category? category);
@@ -27,4 +29,5 @@ public interface IMemeService
     Meme RemoveTag(Meme meme, Tag tag);
 
     Meme SetThumbnailPath(Meme meme, string? thumbnailPath);
+    void SetThumbnailPaths(IEnumerable<(Meme, string?)> thumbnails);
 }

--- a/MemeManager/Services/Abstractions/IMemeService.cs
+++ b/MemeManager/Services/Abstractions/IMemeService.cs
@@ -1,14 +1,12 @@
 ﻿using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
-using MemeManager.Persistence;
 using MemeManager.Persistence.Entity;
 
 namespace MemeManager.Services.Abstractions;
 
 public interface IMemeService
 {
-    IMemeService NewInstance(MemeManagerContext separateContext);
     IEnumerable<Meme> GetAll();
 
     IEnumerable<Meme> GetFiltered(Category? category, string? searchTerms);
@@ -29,5 +27,4 @@ public interface IMemeService
     Meme RemoveTag(Meme meme, Tag tag);
 
     Meme SetThumbnailPath(Meme meme, string? thumbnailPath);
-    void SetThumbnailPaths(IEnumerable<(Meme, string?)> thumbnails);
 }

--- a/MemeManager/Services/Abstractions/ITagService.cs
+++ b/MemeManager/Services/Abstractions/ITagService.cs
@@ -1,12 +1,10 @@
 ﻿using System.Collections.Generic;
-using MemeManager.Persistence;
 using MemeManager.Persistence.Entity;
 
 namespace MemeManager.Services.Abstractions;
 
 public interface ITagService
 {
-    ITagService NewInstance(MemeManagerContext separateContext);
     IEnumerable<Tag> GetAll();
 
     Tag? GetById(int id);

--- a/MemeManager/Services/Implementations/CategoryService.cs
+++ b/MemeManager/Services/Implementations/CategoryService.cs
@@ -22,11 +22,6 @@ public class CategoryService : ICategoryService
     }
 
 
-    public ICategoryService NewInstance(MemeManagerContext separateContext)
-    {
-        return new CategoryService(separateContext, _dbChangeNotifier, _log);
-    }
-
     public IEnumerable<Category> GetAll()
     {
         return _context.Categories.AsNoTracking().ToList();

--- a/MemeManager/Services/Implementations/ImportRequestNotifier.cs
+++ b/MemeManager/Services/Implementations/ImportRequestNotifier.cs
@@ -1,0 +1,29 @@
+﻿using System;
+using System.Collections.Generic;
+using MemeManager.Extensions;
+using MemeManager.Persistence.Entity;
+using MemeManager.Services.Abstractions;
+
+namespace MemeManager.Services.Implementations;
+
+public class ImportRequestNotifier : IImportRequestNotifier
+{
+    public event EventHandler<ImportRequestEventArgs>? ImportRequest;
+    public event EventHandler<GenerateThumbnailsRequestEventArgs>? GenerateThumbnailsRequest;
+    public event EventHandler<SetThumbnailsRequestEventArgs>? SetThumbnailsRequest;
+
+    public void SendImportRequest(string basePath, string[] memePaths)
+    {
+        ImportRequest.Raise(this, new ImportRequestEventArgs(basePath, memePaths));
+    }
+
+    public void SendGenerateThumbnailsRequest(IEnumerable<Meme> memes)
+    {
+        GenerateThumbnailsRequest.Raise(this, new GenerateThumbnailsRequestEventArgs(memes));
+    }
+
+    public void SendSetThumbnailsRequest(IEnumerable<(Meme, string?)> memesAndThumbnailPaths)
+    {
+        SetThumbnailsRequest.Raise(this, new SetThumbnailsRequestEventArgs(memesAndThumbnailPaths));
+    }
+}

--- a/MemeManager/Services/Implementations/ImportService.cs
+++ b/MemeManager/Services/Implementations/ImportService.cs
@@ -9,7 +9,6 @@ using System.Threading.Tasks;
 using MemeManager.Persistence;
 using MemeManager.Persistence.Entity;
 using MemeManager.Services.Abstractions;
-using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Logging;
 using SixLabors.ImageSharp;
 using SixLabors.ImageSharp.Processing;
@@ -346,13 +345,6 @@ public class ImportService : IImportService
                     currentParent = existingCategory;
                 }
             }
-        }
-
-        if (currentParent != null)
-        {
-            using var context = new MemeManagerContext();
-            // I can't get CategoryService.GetTopLevelCategories() to not fucking return tracked CategoryProxy objects
-            context.Categories.Entry(currentParent).State = EntityState.Detached;
         }
 
         return currentParent;

--- a/MemeManager/Services/Implementations/MemeService.cs
+++ b/MemeManager/Services/Implementations/MemeService.cs
@@ -25,11 +25,6 @@ public class MemeService : IMemeService
         _log = logger;
     }
 
-    public IMemeService NewInstance(MemeManagerContext separateContext)
-    {
-        return new MemeService(separateContext, this._dbChangeNotifier, this._log);
-    }
-
     public IEnumerable<Meme> GetAll()
     {
         return _context.Memes.AsNoTracking().ToList();
@@ -120,17 +115,6 @@ public class MemeService : IMemeService
         _context.SaveChanges();
         _dbChangeNotifier.NotifyOfChanges(new[] { typeof(Meme) });
         return meme;
-    }
-
-    public void SetThumbnailPaths(IEnumerable<(Meme, string?)> thumbnails)
-    {
-        foreach (var tuple in thumbnails)
-        {
-            var (meme, thumbnailPath) = tuple;
-            meme.CachedThumbnailPath = thumbnailPath;
-        }
-        _context.SaveChanges();
-        _dbChangeNotifier.NotifyOfChanges(new[] { typeof(Meme) });
     }
 
     private IQueryable<Meme> GetFilteredInternal(Category? category, string? searchTerms)

--- a/MemeManager/Services/Implementations/MemeService.cs
+++ b/MemeManager/Services/Implementations/MemeService.cs
@@ -14,11 +14,13 @@ namespace MemeManager.Services.Implementations;
 
 public class MemeService : IMemeService
 {
+    private readonly MemeManagerContext _context;
     private readonly IDbChangeNotifier _dbChangeNotifier;
     private readonly ILogger _log;
 
     public MemeService(MemeManagerContext context, IDbChangeNotifier dbChangeNotifier, ILogger logger)
     {
+        _context = context;
         _dbChangeNotifier = dbChangeNotifier;
         _log = logger;
     }
@@ -30,110 +32,92 @@ public class MemeService : IMemeService
 
     public IEnumerable<Meme> GetAll()
     {
-        using var context = new MemeManagerContext();
-        return context.Memes.AsNoTracking().ToList();
+        return _context.Memes.AsNoTracking().ToList();
     }
 
     public IEnumerable<Meme> GetFiltered(Category? category, string? searchTerms)
     {
-        using var context = new MemeManagerContext();
-        return GetFilteredInternal(category, searchTerms, context).ToList();
+        return GetFilteredInternal(category, searchTerms).ToList();
     }
 
     public Task<List<Meme>> GetFilteredAsync(Category? category, string? searchTerms, CancellationToken token)
     {
-        using var context = new MemeManagerContext();
-        return GetFilteredInternal(category, searchTerms, context).ToListAsync(token);
+        return GetFilteredInternal(category, searchTerms).ToListAsync(token);
     }
 
     public Meme? GetById(int id)
     {
-        using var context = new MemeManagerContext();
-        return context.Memes.AsNoTracking().SingleOrDefault(m => m.Id == id);
+        return _context.Memes.AsNoTracking().SingleOrDefault(m => m.Id == id);
     }
 
     public Meme? GetByPath(string path)
     {
-        using var context = new MemeManagerContext();
-        return context.Memes.AsNoTracking().SingleOrDefault(m => m.Path == path);
+        return _context.Memes.AsNoTracking().SingleOrDefault(m => m.Path == path);
     }
 
     public Meme Create(Meme newMeme)
     {
-        using var context = new MemeManagerContext();
-        context.Memes.Attach(newMeme);
-        context.Memes.Add(newMeme);
-        context.SaveChanges();
+        _context.Memes.Add(newMeme);
+        _context.SaveChanges();
         _dbChangeNotifier.NotifyOfChanges(new[] { typeof(Meme) });
         return newMeme;
     }
 
     public Meme? DeleteById(int id)
     {
-        using var context = new MemeManagerContext();
-        var existingMeme = context.Memes.SingleOrDefault(m => m.Id == id);
+        var existingMeme = _context.Memes.SingleOrDefault(m => m.Id == id);
         try
         {
-            return existingMeme != null ? context.Memes.Remove(existingMeme).Entity : null;
+            return existingMeme != null ? _context.Memes.Remove(existingMeme).Entity : null;
         }
         finally
         {
-            context.SaveChanges();
+            _context.SaveChanges();
         }
     }
 
     public Meme SetCategory(Meme meme, Category? category)
     {
-        using var context = new MemeManagerContext();
-        context.Memes.Attach(meme);
         meme.Category = category;
         //TODO: The viewmodels don't reflect the changed data until a query is run again. Maybe fire an event here again or do the ReactiveUI this.WhenAnyValue() stuff
-        context.SaveChanges();
+        _context.SaveChanges();
         _dbChangeNotifier.NotifyOfChanges(new[] { typeof(Meme), typeof(Category) });
         return meme;
     }
 
     public Meme SetTags(Meme meme, params Tag[] tags)
     {
-        using var context = new MemeManagerContext();
-        context.Memes.Attach(meme);
         meme.Tags = tags;
         //TODO: The viewmodels don't reflect the changed data until a query is run again. Maybe fire an event here again or do the ReactiveUI this.WhenAnyValue() stuff
-        context.SaveChanges();
+        _context.SaveChanges();
         _dbChangeNotifier.NotifyOfChanges(new[] { typeof(Meme), typeof(Tag) });
         return meme;
     }
 
     public Meme AddTag(Meme meme, Tag tag)
     {
-        using var context = new MemeManagerContext();
-        context.Memes.Attach(meme);
         meme.Tags.Add(tag);
         //TODO: The viewmodels don't reflect the changed data until a query is run again. Maybe fire an event here again or do the ReactiveUI this.WhenAnyValue() stuff
-        context.SaveChanges();
+        _context.SaveChanges();
         _dbChangeNotifier.NotifyOfChanges(new[] { typeof(Meme), typeof(Tag) });
         return meme;
     }
 
     public Meme RemoveTag(Meme meme, Tag tag)
     {
-        using var context = new MemeManagerContext();
-        context.Memes.Attach(meme);
         meme.Tags.Remove(tag);
         //TODO: The viewmodels don't reflect the changed data until a query is run again. Maybe fire an event here again or do the ReactiveUI this.WhenAnyValue() stuff
-        context.SaveChanges();
+        _context.SaveChanges();
         _dbChangeNotifier.NotifyOfChanges(new[] { typeof(Meme), typeof(Tag) });
         return meme;
     }
 
     public Meme SetThumbnailPath(Meme meme, string? thumbnailPath)
     {
-        using var context = new MemeManagerContext();
-        context.Memes.Attach(meme);
         meme.CachedThumbnailPath = thumbnailPath;
         //TODO: The viewmodels don't reflect the changed data until a query is run again. Maybe fire an event here again or do the ReactiveUI this.WhenAnyValue() stuff
         //TODO: The above TODO seems to not be true. Investigate if I still need to make any change pertaining to the above comment.
-        context.SaveChanges();
+        _context.SaveChanges();
         _dbChangeNotifier.NotifyOfChanges(new[] { typeof(Meme) });
         return meme;
     }
@@ -142,21 +126,18 @@ public class MemeService : IMemeService
     {
         foreach (var tuple in thumbnails)
         {
-            using var context = new MemeManagerContext();
             var (meme, thumbnailPath) = tuple;
-            context.Memes.Attach(meme);
             meme.CachedThumbnailPath = thumbnailPath;
-            context.SaveChanges();
         }
-
+        _context.SaveChanges();
         _dbChangeNotifier.NotifyOfChanges(new[] { typeof(Meme) });
     }
 
-    private IQueryable<Meme> GetFilteredInternal(Category? category, string? searchTerms, MemeManagerContext context)
+    private IQueryable<Meme> GetFilteredInternal(Category? category, string? searchTerms)
     {
         // TODO: Maybe add an option to include memes from all child categories as well
         _log.LogDebug("Starting search for category {CategoryName}...", category?.Name);
-        var query = context.Memes
+        var query = _context.Memes
             // Return all memes if the category is null. Otherwise, filter by the category.
             .Where(meme => category == null || meme.Category == category);
         if (searchTerms != null && searchTerms.Length > 0)

--- a/MemeManager/Services/Implementations/MemeService.cs
+++ b/MemeManager/Services/Implementations/MemeService.cs
@@ -58,6 +58,13 @@ public class MemeService : IMemeService
         return newMeme;
     }
 
+    public void BulkCreate(IEnumerable<Meme> memes)
+    {
+        _context.Memes.AddRange(memes);
+        _context.SaveChanges();
+        _dbChangeNotifier.NotifyOfChanges(new[] { typeof(Meme) });
+    }
+
     public Meme? DeleteById(int id)
     {
         var existingMeme = _context.Memes.SingleOrDefault(m => m.Id == id);
@@ -115,6 +122,17 @@ public class MemeService : IMemeService
         _context.SaveChanges();
         _dbChangeNotifier.NotifyOfChanges(new[] { typeof(Meme) });
         return meme;
+    }
+
+    public void SetThumbnailPaths(IEnumerable<(Meme, string?)> thumbnails)
+    {
+        foreach (var tuple in thumbnails)
+        {
+            var (meme, thumbnailPath) = tuple;
+            meme.CachedThumbnailPath = thumbnailPath;
+        }
+        _context.SaveChanges();
+        _dbChangeNotifier.NotifyOfChanges(new[] { typeof(Meme) });
     }
 
     private IQueryable<Meme> GetFilteredInternal(Category? category, string? searchTerms)

--- a/MemeManager/Services/Implementations/TagService.cs
+++ b/MemeManager/Services/Implementations/TagService.cs
@@ -21,11 +21,6 @@ public class TagService : ITagService
         _log = logger;
     }
 
-    public ITagService NewInstance(MemeManagerContext separateContext)
-    {
-        return new TagService(separateContext, _dbChangeNotifier, _log);
-    }
-
     public IEnumerable<Tag> GetAll()
     {
         return _context.Tags.ToList();

--- a/MemeManager/ViewModels/Implementations/MainWindowViewModel.cs
+++ b/MemeManager/ViewModels/Implementations/MainWindowViewModel.cs
@@ -1,4 +1,5 @@
-﻿using System.Reactive.Concurrency;
+﻿using System;
+using System.Reactive.Concurrency;
 using System.Threading.Tasks;
 using System.Windows.Input;
 using Avalonia.Controls;
@@ -45,13 +46,15 @@ namespace MemeManager.ViewModels.Implementations
         {
             var dialogViewModel = _dialogService.CreateViewModel<IImportFolderDialogViewModel>();
             var success = await _dialogService.ShowDialogAsync<ImportFolderDialog>(this, dialogViewModel).ConfigureAwait(true);
-            if (success == true && dialogViewModel.Path != null)
+            if (success == true&&dialogViewModel.Path!=null)
             {
                 var importedMemes = _importService.ImportFromDirectory(dialogViewModel.Path);
                 RxApp.TaskpoolScheduler.Schedule(() =>
                 {
-                    _importService.GenerateThumbnails(importedMemes);
+                    Task.Delay(3000);
+                     _importService.GenerateThumbnails(importedMemes);
                 });
+                Console.WriteLine();
             }
         }
     }


### PR DESCRIPTION
This reverts commit 9203dcb73deec34b3679aee80f0a832fa1969d8c and acbd2a1720983ae76812baee9cb59d4d178f39c4.

This PR adds a hacky workaround to ~~ab~~use Entity Framework from multiple threads even though I'm not supposed to. To do this, I use C# events and a new class `ImportRequestNotifier` to notify the `MainWindowViewModel` to kick off an action on the main or a background thread.