### PR TITLE
Limit the number of memes shown on the "home" screen

### DIFF
--- a/MemeManager/Services/Implementations/ImportService.cs
+++ b/MemeManager/Services/Implementations/ImportService.cs
@@ -62,6 +62,7 @@ public class ImportService : IImportService
      * - Additional file extensions to include and what media type they are (in case I'm missing any in the extensions lists)
      * - Skip generating thumbnails
      * - Files to skip (a regexp for a file name or names)
+     * - Make the imported date the file's creation date
      */
     public void ImportFromDirectory(string path)
     {

--- a/MemeManager/Services/Implementations/MemeService.cs
+++ b/MemeManager/Services/Implementations/MemeService.cs
@@ -137,6 +137,17 @@ public class MemeService : IMemeService
 
     private IQueryable<Meme> GetFilteredInternal(Category? category, string? searchTerms)
     {
+        /*
+         * If there are no search terms and the category is null, we're probably on the home page.
+         * We want to show the user all their memes on the home page. However, if they have a big library it could
+         * cause the UI to freeze. Instead of showing the user ALL their memes, just show some of the
+         * most recently imported ones.
+         */
+        if (category == null && string.IsNullOrEmpty(searchTerms))
+        {
+            return _context.Memes.OrderBy(meme => meme.TimeAdded).Take(50);
+        }
+
         // TODO: Maybe add an option to include memes from all child categories as well
         _log.LogDebug("Starting search for category {CategoryName}...", category?.Name);
         var query = _context.Memes
@@ -156,6 +167,7 @@ public class MemeService : IMemeService
                 // Call this function last to help with compatability issue https://github.com/ninjanye/SearchExtensions/issues/40
                 .Apply();
         }
+        // TODO: Might want to sort by time added in an else{} block here (so that they're sorted in a reasonable way if they're not already being sorted by search relevance)
 
         return query;
     }

--- a/MemeManager/ViewModels/Implementations/MainWindowViewModel.cs
+++ b/MemeManager/ViewModels/Implementations/MainWindowViewModel.cs
@@ -35,6 +35,7 @@ namespace MemeManager.ViewModels.Implementations
             _importService = importService;
             ImportCommand = ReactiveCommand.CreateFromTask(OpenImportDialog);
 
+            // TODO: Since I don't need to perform operations on the UI thread anymore, there's no need for these observables anymore. ImportService can just call its other methods.  
             #region Terrible, awful hack to allow for a background Task to do all EF operations on the UI thread to avoid DbContext threading issues
 
             _importRequestObservable =


### PR DESCRIPTION
When no category is selected and no search terms are entered, the memes displayed are the most recently imported memes. If the library is huge, EF will throw an error on startup. This is because the categories are having their navigation properties accessed to draw the categories view while the memes list is still being populated. This will eventually be solved with #69. However, I think there may also be a slight performance benefit to doing this.